### PR TITLE
Added utterances to reduce clashing with other light controlling skills

### DIFF
--- a/.idea/PhillipsHue.iml
+++ b/.idea/PhillipsHue.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/PhilipsHue.install
+++ b/PhilipsHue.install
@@ -1,15 +1,16 @@
 {
-    "name": "PhilipsHue",
-    "version": "1.1.23",
-    "icon": "far fa-lightbulb",
-    "category": "automation",
-    "author": "Psychokiller1888",
-    "maintainers": [
-        "Jierka",
-        "maxbachmann",
-        "Fe3lApAcUt"
-    ],
-    "desc": "Control your Philips Hue lamps",
+	"name": "PhilipsHue",
+	"version": "1.1.24",
+	"icon": "far fa-lightbulb",
+	"category": "automation",
+	"author": "Psychokiller1888",
+	"maintainers": [
+		"Jierka",
+		"maxbachmann",
+		"Fe3lApAcUt",
+		"lazza"
+	],
+	"desc": "Control your Philips Hue lamps",
     "aliceMinVersion": "1.0.0-b3",
     "systemRequirements": [],
     "pipRequirements": [],

--- a/dialogTemplate/de.json
+++ b/dialogTemplate/de.json
@@ -203,6 +203,20 @@
 					"synonyms": []
 				}
 			]
+		},
+		{
+			"name": "LightBrand",
+			"matchingStrictness": null,
+			"automaticallyExtensible": true,
+			"useSynonyms": true,
+			"values": [
+				{
+					"value": "Phillips Hue",
+					"synonyms": [
+						"hue"
+					]
+				}
+			]
 		}
 	],
 	"intents": [
@@ -211,6 +225,13 @@
 			"enabledByDefault": true,
 			"utterances": [
 				"Bitte {überall:=>Location} Licht aus",
+				"please lights off {hue:=>LightBrand} {everywhere:=>Location}",
+				"please turn off the {office:=>Location} {hue:=>LightBrand} light",
+				"turn the {office:=>Location} {Phillips Hue:=>LightBrand} lights off",
+				"{Phillips Hue:=>LightBrand} lights off {everywhere:=>Location}",
+				"{hue:=>LightBrand} Light off in the {kitchen:=>Location} and {bathroom:=>Location}",
+				"Can I have the {hue:=>LightBrand} light off in the {kitchen:=>Location} please",
+				"turn off the {hue:=>LightBrand} lights",
 				"Bitte schalte das {Büro:=>Location} Licht aus",
 				"Schalte das {Büro:=>Location} Licht aus",
 				"Kannst du bitte das Licht im {Büro:=>Location} ausschalten",
@@ -256,6 +277,12 @@
 					"name": "Location",
 					"required": false,
 					"type": "Alice/Location",
+					"missingQuestion": ""
+				},
+				{
+					"name": "LightBrand",
+					"required": false,
+					"type": "LightBrand",
 					"missingQuestion": ""
 				}
 			]
@@ -325,6 +352,12 @@
 					"required": false,
 					"type": "snips/percentage",
 					"missingQuestion": ""
+				},
+				{
+					"name": "LightBrand",
+					"required": false,
+					"type": "LightBrand",
+					"missingQuestion": ""
 				}
 			]
 		},
@@ -367,6 +400,12 @@
 					"name": "Location",
 					"required": false,
 					"type": "Alice/Location",
+					"missingQuestion": ""
+				},
+				{
+					"name": "LightBrand",
+					"required": false,
+					"type": "LightBrand",
 					"missingQuestion": ""
 				}
 			]
@@ -434,6 +473,12 @@
 					"required": false,
 					"type": "Alice/Location",
 					"missingQuestion": "In which location?"
+				},
+				{
+					"name": "LightBrand",
+					"required": false,
+					"type": "LightBrand",
+					"missingQuestion": ""
 				}
 			]
 		},
@@ -545,6 +590,12 @@
 					"name": "Location",
 					"required": false,
 					"type": "Alice/Location",
+					"missingQuestion": ""
+				},
+				{
+					"name": "LightBrand",
+					"required": false,
+					"type": "LightBrand",
 					"missingQuestion": ""
 				}
 			]

--- a/dialogTemplate/en.json
+++ b/dialogTemplate/en.json
@@ -99,6 +99,20 @@
 					"synonyms": []
 				}
 			]
+		},
+		{
+			"name": "LightBrand",
+			"matchingStrictness": null,
+			"automaticallyExtensible": true,
+			"useSynonyms": true,
+			"values": [
+				{
+					"value": "Phillips Hue",
+					"synonyms": [
+						"hue"
+					]
+				}
+			]
 		}
 	],
 	"intents": [
@@ -107,6 +121,13 @@
 			"enabledByDefault": true,
 			"utterances": [
 				"please lights off {everywhere:=>Location}",
+				"please lights off {hue:=>LightBrand} {everywhere:=>Location}",
+				"please turn off the {office:=>Location} {hue:=>LightBrand} light",
+				"turn the {office:=>Location} {Phillips Hue:=>LightBrand} lights off",
+				"{Phillips Hue:=>LightBrand} lights off {everywhere:=>Location}",
+				"{hue:=>LightBrand} Light off in the {kitchen:=>Location} and {bathroom:=>Location}",
+				"Can I have the {hue:=>LightBrand} light off in the {kitchen:=>Location} please",
+				"turn off the {hue:=>LightBrand} lights",
 				"please turn off the {office:=>Location} light",
 				"turn the {office:=>Location} lights off",
 				"could you please turn the {office:=>Location} light off",
@@ -130,6 +151,12 @@
 					"required": false,
 					"type": "Alice/Location",
 					"missingQuestion": ""
+				},
+				{
+					"name": "LightBrand",
+					"required": false,
+					"type": "LightBrand",
+					"missingQuestion": ""
 				}
 			]
 		},
@@ -138,13 +165,19 @@
 			"enabledByDefault": true,
 			"utterances": [
 				"set to {50%:=>Percent} the lights in the {kitchen:=>Location}",
+				"set to {50%:=>Percent} the {hue:=>LightBrand} lights in the {kitchen:=>Location}",
 				"please set the lights in the {kitchen:=>Location} to {50%:=>Percent}",
+				"please set the {hue:=>LightBrand} lights in the {kitchen:=>Location} to {50%:=>Percent}",
 				"dim the light {everywhere:=>Location} to {50 percent:=>Percent}",
+				"dim the {hue:=>LightBrand} lights {everywhere:=>Location} to {50 percent:=>Percent}",
 				"please dim the lights to {25%:=>Percent}",
+				"please dim the {hue:=>LightBrand} lights to {25%:=>Percent}",
 				"dim the lights in the {kitchen:=>Location} to {25%:=>Percent}",
 				"dim the lights in the {bedroom:=>Location}",
+				"dim the {hue:=>LightBrand} lights in the {bedroom:=>Location}",
 				"dim the lights to {25 percent:=>Percent}",
 				"please dim the lights",
+				"please dim the {hue:=>LightBrand} lights",
 				"dim the lights"
 			],
 			"slots": [
@@ -159,6 +192,12 @@
 					"required": false,
 					"type": "snips/percentage",
 					"missingQuestion": ""
+				},
+				{
+					"name": "LightBrand",
+					"required": false,
+					"type": "LightBrand",
+					"missingQuestion": ""
 				}
 			]
 		},
@@ -168,17 +207,22 @@
 			"utterances": [
 				"please lights {everywhere:=>Location}",
 				"lights {everywhere:=>Location} please",
+				"{hue:=>LightBrand} lights {everywhere:=>Location} please",
 				"lights {everywhere:=>Location}",
+				"{hue:=>LightBrand} lights {everywhere:=>Location}",
 				"please light in the {bathroom:=>Location}",
+				"toggle {hue:=>LightBrand} light in the {office:=>Location}",
 				"light in the {office:=>Location}",
 				"lights in the {office:=>Location} please",
 				"toggle lights in the {entrance:=>Location}",
 				"toggle the lights in the {kitchen:=>Location}",
 				"lights in the {kitchen:=>Location}",
 				"toggle the lights please",
+				"toggle the {hue:=>LightBrand} please",
 				"please toggle the lights",
 				"toggle the lights",
 				"lights please",
+				"{hue:=>LightBrand} lights please",
 				"please lights"
 			],
 			"slots": [
@@ -186,6 +230,12 @@
 					"name": "Location",
 					"required": false,
 					"type": "Alice/Location",
+					"missingQuestion": ""
+				},
+				{
+					"name": "LightBrand",
+					"required": false,
+					"type": "LightBrand",
 					"missingQuestion": ""
 				}
 			]
@@ -197,6 +247,12 @@
 				"light in the {office:=>Location}",
 				"please turn on the {office:=>Location} light",
 				"lights",
+				"please turn on the {office:=>Location} {hue:=>LightBrand} light",
+				"turn the {office:=>Location} {Phillips Hue:=>LightBrand} lights on",
+				"{Phillips Hue:=>LightBrand} lights on {everywhere:=>Location}",
+				"turn on the {hue:=>LightBrand} lights",
+				"{hue:=>LightBrand} Light on in the {kitchen:=>Location} and {bathroom:=>Location}",
+				"Can I have the {hue:=>LightBrand} light in the {kitchen:=>Location} please",
 				"turn on the lights {everywhere:=>Location}",
 				"please turn on the lights {everywhere:=>Location}",
 				"lights on {everywhere:=>Location}",
@@ -210,7 +266,9 @@
 				"Illuminate the {kitchen:=>Location}",
 				"Please light the {kitchen:=>Location}",
 				"Lights on in the {kitchen:=>Location}",
-				"Turn on the lights in the {kitchen:=>Location}"
+				"{hue:=>LightBrand} Lights on in the {kitchen:=>Location}",
+				"Turn on the lights in the {kitchen:=>Location}",
+				"Turn on the {hue:=>LightBrand} lights in the {kitchen:=>Location}"
 			],
 			"slots": [
 				{
@@ -218,6 +276,12 @@
 					"required": false,
 					"type": "Alice/Location",
 					"missingQuestion": "In which location?"
+				},
+				{
+					"name": "LightBrand",
+					"required": false,
+					"type": "LightBrand",
+					"missingQuestion": ""
 				}
 			]
 		},
@@ -226,29 +290,37 @@
 			"enabledByDefault": true,
 			"utterances": [
 				"change the lights in the {bedroom:=>Location} to {going bed:=>Scene}",
+				"change the {hue:=>LightBrand} lights in the {bedroom:=>Location} to {going bed:=>Scene}",
 				"change the light in the {bedroom:=>Location} to {going bed:=>Scene}",
+				"change the {hue:=>LightBrand} light in the {bedroom:=>Location} to {going bed:=>Scene}",
 				"set the light in the {living room:=>Location} to {watching tv:=>Scene}",
+				"set the {hue:=>LightBrand} light in the {living room:=>Location} to {watching tv:=>Scene}",
 				"set the lights in the {living room:=>Location} to {watching tv:=>Scene}",
 				"set the light to {energize:=>Scene} please",
 				"set the lights to {read:=>Scene}",
+				"set the {hue:=>LightBrand} lights to {read:=>Scene}",
 				"change the light to {relax:=>Scene}",
+				"change the {hue:=>LightBrand} light to {relax:=>Scene}",
 				"change the lights to {concentrate:=>Scene}",
 				"change the light to {going bed:=>Scene} in the {bedroom:=>Location}",
 				"set the lights to {watching tv:=>Scene} in the {living room:=>Location}",
 				"lights to {eating:=>Scene} in the {living room:=>Location}",
 				"set the lights to {relax:=>Scene}",
 				"lights in the {bedroom:=>Location} to {daylight:=>Scene}",
+				"{hue:=>LightBrand} lights in the {bedroom:=>Location} to {daylight:=>Scene}",
 				"change the lights to {going bed:=>Scene}",
 				"lights to {day light:=>Scene}",
 				"set the lights in the {kitchen:=>Location} to {day light:=>Scene}",
 				"set the {bedroom:=>Location} lights to {waking up:=>Scene}",
 				"set the {bedroom:=>Location} scene to {waking up:=>Scene}",
+				"set the {bedroom:=>Location} {hue:=>LightBrand} scene to {waking up:=>Scene}",
 				"set the {bedroom:=>Location} light scenery to {going bed:=>Scene}",
 				"change the lights in the {living room:=>Location} to {watching tv:=>Scene}",
 				"change the lighting to {watching tv:=>Scene}",
 				"please set the scenery to {watching tv:=>Scene}",
 				"set the scenery to {watching tv:=>Scene}",
 				"set the light scenery to {day light:=>Scene}",
+				"set the {hue:=>LightBrand} light scenery to {day light:=>Scene}",
 				"set the lights to {going bed:=>Scene}"
 			],
 			"slots": [
@@ -262,6 +334,12 @@
 					"name": "Location",
 					"required": false,
 					"type": "Alice/Location",
+					"missingQuestion": ""
+				},
+				{
+					"name": "LightBrand",
+					"required": false,
+					"type": "LightBrand",
 					"missingQuestion": ""
 				}
 			]

--- a/instructions/en.md
+++ b/instructions/en.md
@@ -1,0 +1,30 @@
+##Use this skill to control your Phillips Hue lights.
+
+#### Setup,:
+
+- Configure Alice to your PhilipsHue hub. Alice will run you through these steps so please 
+listen to her requests when you install the skill.
+
+#### Usage :
+
+Some examples of what to say :
+
+- "turn the office lights off"
+- "turn the office lights on"
+- "set to 50% the lights in the kitchen"
+- "toggle light in the office"
+- "change the lights in the bedroom to going bed"
+
+###NOTE: 
+
+If you have another skill installed that also controls lights, such as the Home Assistant skill. You may find 
+that skill will take dominance over your Phillips hue lights. In that case, try using utterances where 
+"hue" or "philips hue" is in the utterance. Often just before the word light.
+
+Example:  
+
+- "turn the office hue lights off"
+- "turn the office phillips hue lights on"
+- "set to 50% the Hue lights in the kitchen"
+- "toggle Hue light in the office"
+- "change the Philips hue lights in the bedroom to going bed"


### PR DESCRIPTION
##### Summary

**helping skills to coexist**
Added additional utterances to the dialogTemplate file so that there is a work around for clashing skills.

HomeAssistant skill for example would dominate the intent capture when asking for a "light" to be turned on and off.Causing hue skill to not trigger when trying to turn off a hue light.

 "Light is a relevant word however homeassistant light is not natural but hue light (brand name) is,
 so the dialogTemplate now has additions of "turn on the "hue" light in the bedroom etc to help force Alice to trigger the hue skill intents. Probably not ideal in long term ?  but it works :) 

##### What kind of change does this PR introduce?

<!-- Check at least one -->

- [ ] Bugfix
- [ ] New feature
- [x] Refactoring
- [ ] Other, please describe:

##### Does this PR introduce a breaking change?

<!-- Check one -->

- [ ] Yes
- [ ] No

<!-- If yes, please describe the path to migrate existing installs to this: -->
###### Migration guide:

<!-- How to migrate from existing Alice's installs -->

##### The PR fulfills these requirements:

- [ ] When resolving/implementing a specific issue, it's referenced in the PR's title (e.g. `fix #xxx` or `implement #xxx`, where "xxx" is the issue number)
- [x] You have tested your changes on the branch you wish to merge {@MPBS has as i dont have hue lights}
- [x] The changes are working


If adding a **new feature**, the PR's description includes:

- [ ] The reason for this new feature to be added
- [ ] The use of this new feature
- [ ] If available, a link to an existing feature request ticket


###### Other information:
